### PR TITLE
FEAT: OAuth 2.0 로그인 기능 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ dependencies {
 
 	//Spring Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	//Spring OAuth 2.0
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/gongjibot/ragchat/config/SecurityConfig.java
+++ b/src/main/java/com/gongjibot/ragchat/config/SecurityConfig.java
@@ -5,6 +5,9 @@ import com.gongjibot.ragchat.filter.CustomJsonUsernamePasswordAuthenticationFilt
 import com.gongjibot.ragchat.filter.JwtAuthenticationProcessingFilter;
 import com.gongjibot.ragchat.handler.LoginFailureHandler;
 import com.gongjibot.ragchat.handler.LoginSuccessHandler;
+import com.gongjibot.ragchat.oauth2.handler.OAuth2LoginFailureHandler;
+import com.gongjibot.ragchat.oauth2.handler.OAuth2LoginSuccessHandler;
+import com.gongjibot.ragchat.oauth2.service.CustomOAuth2UserService;
 import com.gongjibot.ragchat.repository.UserRepository;
 import com.gongjibot.ragchat.service.JwtService;
 import com.gongjibot.ragchat.service.LoginService;
@@ -35,6 +38,9 @@ public class SecurityConfig {
     private final JwtService jwtService;
     private final UserRepository userRepository;
     private final ObjectMapper objectMapper;
+    private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+    private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
+    private final CustomOAuth2UserService customOAuth2UserService;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -68,6 +74,15 @@ public class SecurityConfig {
                 
                 // 나머지 모든 요청은 인증 필요
                 .anyRequest().authenticated()
+            )
+
+            // 소셜 로그인 설정
+            .oauth2Login(oauth2 -> oauth2
+                .successHandler(oAuth2LoginSuccessHandler)
+                .failureHandler(oAuth2LoginFailureHandler)
+                .userInfoEndpoint(userInfo -> userInfo
+                    .userService(customOAuth2UserService)
+                )
             )
             
             // 필터 순서 설정

--- a/src/main/java/com/gongjibot/ragchat/controller/UserController.java
+++ b/src/main/java/com/gongjibot/ragchat/controller/UserController.java
@@ -34,12 +34,12 @@ public class UserController {
         return "jwtTest 요청 성공";
     }
 
-    @PostMapping("find-id")
-    public ResponseEntity<FindIdResponseDto> findId(@RequestBody @Valid FindIdRequestDto requestBody) {
-        String username = userService.findId(requestBody);
-        FindIdResponseDto responseDto = new FindIdResponseDto(username);
-        return ResponseEntity.ok(responseDto);
-    }
+    // @PostMapping("find-id")
+    // public ResponseEntity<FindIdResponseDto> findId(@RequestBody @Valid FindIdRequestDto requestBody) {
+    //     String username = userService.findId(requestBody);
+    //     FindIdResponseDto responseDto = new FindIdResponseDto(username);
+    //     return ResponseEntity.ok(responseDto);
+    // }
 
     @PostMapping("/password-reset")
     public ResponseEntity<Void> passwordReset(@RequestBody @Valid PasswordResetDto requestBody) {

--- a/src/main/java/com/gongjibot/ragchat/dto/SignUpRequestDto.java
+++ b/src/main/java/com/gongjibot/ragchat/dto/SignUpRequestDto.java
@@ -4,16 +4,13 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
 public record SignUpRequestDto (
-        @NotBlank(message = "아이디는 필수 입력 값입니다.")
-        String username,
+        @NotBlank(message = "이메일은 필수 입력 값입니다.")
+        @Pattern(regexp = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$", message = "이메일 형식이 올바르지 않습니다.")
+        String email,
 
         @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
         @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[#@$!%\\?&])[A-Za-z0-9#@$!%\\?&]{8,13}$", message = "비밀번호는 8~13자 영문 대소문자, 숫자, 특수문자를 사용하세요.")
         String password,
-
-        @NotBlank(message = "이메일은 필수 입력 값입니다.")
-        @Pattern(regexp = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$", message = "이메일 형식이 올바르지 않습니다.")
-        String email,
 
         @NotBlank(message = "닉네임은 필수 입력 값입니다.")
         String nickname,

--- a/src/main/java/com/gongjibot/ragchat/entity/User.java
+++ b/src/main/java/com/gongjibot/ragchat/entity/User.java
@@ -22,23 +22,16 @@ public class User extends BaseEntity {
     @Column(name = "user_id")
     private Long id;
 
-    @Column(name = "username", nullable = false)
-    private String username;
-
-    @Column(name = "password", nullable = false)
-    private String password;
-
     @Column(name = "email", nullable = false)
     private String email;
+
+    // OAuth 사용자는 null 가능
+    @Column(name = "password")
+    private String password;
 
     @Size(max = MAX_NICKNAME_LENGTH)
     @Column(name = "nickname", nullable = false)
     private String nickname;
-
-    @JsonIgnore
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
-    @JoinColumn(name = "certification_id")
-    private Certification certification;
 
     @Enumerated(EnumType.STRING)
     private Role role;
@@ -47,6 +40,17 @@ public class User extends BaseEntity {
     private SocialType socialType; // KAKAO, GOOGLE, NAVER
 
     private String socialId;
+
+    // OAuth 관련 필드
+    // 일반 사용자는 모두 null 값을 가짐
+    private String imageUrl;
+    private int age;
+    private String city;
+
+    @JsonIgnore
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "certification_id")
+    private Certification certification;
 
     private String refreshToken;
 
@@ -58,17 +62,20 @@ public class User extends BaseEntity {
         this.refreshToken = refreshToken;
     }
 
-    @Builder
-    public User(String username, String password, String email, String nickname, Role role, Certification certification) {
-        this.username = username;
-        this.password = password;
-        this.email = email;
-        this.nickname = nickname;
-        this.role = role;
-        this.certification = certification;
-    }
-
     public void updatePassword(String newPassword) {
         this.password = newPassword;
+    }
+    
+    @Builder
+    public User(String email, String password, String nickname, Role role,
+                SocialType socialType, String socialId, String imageUrl, Certification certification) {
+        this.email = email;
+        this.password = password;
+        this.nickname = nickname;
+        this.role = role;
+        this.socialType = socialType;
+        this.socialId = socialId;
+        this.imageUrl = imageUrl;
+        this.certification = certification;
     }
 }

--- a/src/main/java/com/gongjibot/ragchat/oauth2/CustomOAuth2User.java
+++ b/src/main/java/com/gongjibot/ragchat/oauth2/CustomOAuth2User.java
@@ -1,0 +1,27 @@
+package com.gongjibot.ragchat.oauth2;
+
+import com.gongjibot.ragchat.common.Role;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * DefaultOAuth2User를 상속하고, email과 role 필드를 추가로 가진다.
+ */
+@Getter
+public class CustomOAuth2User extends DefaultOAuth2User {
+
+    private String email;
+    private Role role;
+
+    public CustomOAuth2User(Collection<? extends GrantedAuthority> authorities,
+                            Map<String, Object> attribute, String nameAttributeKey,
+                            String email, Role role) {
+        super(authorities, attribute, nameAttributeKey);
+        this.email = email;
+        this.role = role;
+    }
+}

--- a/src/main/java/com/gongjibot/ragchat/oauth2/OAuthAttributes.java
+++ b/src/main/java/com/gongjibot/ragchat/oauth2/OAuthAttributes.java
@@ -1,0 +1,86 @@
+package com.gongjibot.ragchat.oauth2;
+
+import com.gongjibot.ragchat.common.Role;
+import com.gongjibot.ragchat.common.SocialType;
+import com.gongjibot.ragchat.entity.User;
+import com.gongjibot.ragchat.oauth2.userinfo.GoogleOAuth2UserInfo;
+import com.gongjibot.ragchat.oauth2.userinfo.KakaoOAuth2UserInfo;
+import com.gongjibot.ragchat.oauth2.userinfo.NaverOAuth2UserInfo;
+import com.gongjibot.ragchat.oauth2.userinfo.OAuth2UserInfo;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * 각 소셜에서 받아오는 데이터가 다르므로
+ * 소셜별로 데이터를 받는 데이터를 분기 처리하는 DTO 클래스
+ */
+@Getter
+public class OAuthAttributes {
+    private String nameAttributeKey; // OAuth2 로그인 진행 시 키가 되는 필드 값, PK와 같은 의미
+    private OAuth2UserInfo oAuth2UserInfo; // 소셜 타입별 로그인 유저 정보(닉네임, 이메일, 프로필 사진 등등)
+
+    @Builder
+    private OAuthAttributes(String nameAttributeKey, OAuth2UserInfo oauth2UserInfo) {
+        this.nameAttributeKey = nameAttributeKey;
+        this.oAuth2UserInfo = oauth2UserInfo;
+    }
+
+    /**
+     * SocialType에 맞는 메소드 호출하여 OAuthAttributes 객체 반환
+     * 파라미터 : userNameAttributeName -> OAuth2 로그인 시 키(PK)가 되는 값 / attributes : OAuth 서비스의 유저 정보들
+     * 소셜별 of 메소드(ofGoogle, ofKaKao, ofNaver)들은 각각 소셜 로그인 API에서 제공하는
+     * 회원의 식별값(id), attributes, nameAttributeKey를 저장 후 build
+     */
+    public static OAuthAttributes of(SocialType socialType,
+                                     String userNameAttributeName, Map<String, Object> attributes) {
+
+        if (socialType == SocialType.NAVER) {
+            return ofNaver(userNameAttributeName, attributes);
+        }
+        if (socialType == SocialType.KAKAO) {
+            return ofKakao(userNameAttributeName, attributes);
+        }
+        return ofGoogle(userNameAttributeName, attributes);
+    }
+
+    private static OAuthAttributes ofKakao(String userNameAttributeName, Map<String, Object> attributes) {
+        return OAuthAttributes.builder()
+                .nameAttributeKey(userNameAttributeName)
+                .oauth2UserInfo(new KakaoOAuth2UserInfo(attributes))
+                .build();
+    }
+
+    public static OAuthAttributes ofGoogle(String userNameAttributeName, Map<String, Object> attributes) {
+        return OAuthAttributes.builder()
+                .nameAttributeKey(userNameAttributeName)
+                .oauth2UserInfo(new GoogleOAuth2UserInfo(attributes))
+                .build();
+    }
+
+    public static OAuthAttributes ofNaver(String userNameAttributeName, Map<String, Object> attributes) {
+        return OAuthAttributes.builder()
+                .nameAttributeKey(userNameAttributeName)
+                .oauth2UserInfo(new NaverOAuth2UserInfo(attributes))
+                .build();
+    }
+
+    /**
+     * of메소드로 OAuthAttributes 객체가 생성되어, 유저 정보들이 담긴 OAuth2UserInfo가 소셜 타입별로 주입된 상태
+     * OAuth2UserInfo에서 socialId(식별값), nickname, imageUrl을 가져와서 build
+     * email에는 UUID로 중복 없는 랜덤 값 생성
+     * role은 GUEST로 설정
+     */
+    public User toEntity(SocialType socialType, OAuth2UserInfo oauth2UserInfo) {
+        return User.builder()
+                .socialType(socialType)
+                .socialId(oauth2UserInfo.getId())
+                .email(UUID.randomUUID() + "@socialUser.com")
+                .nickname(oauth2UserInfo.getNickname())
+                .imageUrl(oauth2UserInfo.getImageUrl())
+                .role(Role.GUEST)
+                .build();
+    }
+}

--- a/src/main/java/com/gongjibot/ragchat/oauth2/handler/OAuth2LoginFailureHandler.java
+++ b/src/main/java/com/gongjibot/ragchat/oauth2/handler/OAuth2LoginFailureHandler.java
@@ -1,0 +1,23 @@
+package com.gongjibot.ragchat.oauth2.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        response.getWriter().write("소셜 로그인 실패! 서버 로그를 확인해주세요.");
+        log.info("소셜 로그인에 실패했습니다. 에러 메시지 : {}", exception.getMessage());
+    }
+}

--- a/src/main/java/com/gongjibot/ragchat/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/gongjibot/ragchat/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,62 @@
+package com.gongjibot.ragchat.oauth2.handler;
+
+import com.gongjibot.ragchat.common.Role;
+import com.gongjibot.ragchat.oauth2.CustomOAuth2User;
+import com.gongjibot.ragchat.repository.UserRepository;
+import com.gongjibot.ragchat.service.JwtService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final JwtService jwtService;
+    private final UserRepository userRepository;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        log.info("OAuth2 Login 성공!");
+
+        try {
+            CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+
+            // User의 Role이 GUEST일 경우 처음 요청한 회원이므로 회원가입 페이지로 리다이렉트
+            if(oAuth2User.getRole() == Role.GUEST) {
+                String accessToken = jwtService.createAccessToken(oAuth2User.getEmail());
+                response.addHeader(jwtService.getAccessHeader(), "Bearer " + accessToken);
+                response.sendRedirect("oauth2/sign-up"); // 프론트의 회원가입 추가 정보 입력 폼으로 리다이렉트
+
+                jwtService.sendAccessAndRefreshToken(response, accessToken, null);
+//                User findUser = userRepository.findByEmail(oAuth2User.getEmail())
+//                                .orElseThrow(() -> new IllegalArgumentException("이메일에 해당하는 유저가 없습니다."));
+//                findUser.authorizeUser();
+            } else {
+                loginSuccess(response, oAuth2User); // 로그인에 성공한 경우 access, refresh 토큰 생성
+            }
+        } catch (Exception e) {
+            throw e;
+        }
+    }
+
+    // TODO : 소셜 로그인 시에도 무조건 토큰 생성하지 말고 JWT 인증 필터처럼 RefreshToken 유/무에 따라 다르게 처리해보기
+    private void loginSuccess(HttpServletResponse response, CustomOAuth2User oAuth2User) throws IOException {
+        String accessToken = jwtService.createAccessToken(oAuth2User.getEmail());
+        String refreshToken = jwtService.createRefreshToken();
+        response.addHeader(jwtService.getAccessHeader(), "Bearer " + accessToken);
+        response.addHeader(jwtService.getRefreshHeader(), "Bearer " + refreshToken);
+
+        jwtService.sendAccessAndRefreshToken(response, accessToken, refreshToken);
+        jwtService.updateRefreshTokenOAuth2(oAuth2User.getEmail(), refreshToken);
+    }
+}

--- a/src/main/java/com/gongjibot/ragchat/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/gongjibot/ragchat/oauth2/service/CustomOAuth2UserService.java
@@ -1,0 +1,109 @@
+package com.gongjibot.ragchat.oauth2.service;
+
+import com.gongjibot.ragchat.common.SocialType;
+import com.gongjibot.ragchat.entity.User;
+import com.gongjibot.ragchat.oauth2.CustomOAuth2User;
+import com.gongjibot.ragchat.oauth2.OAuthAttributes;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import com.gongjibot.ragchat.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Collections;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+    
+    private final UserRepository userRepository;
+
+    private static final String NAVER = "naver";
+    private static final String KAKAO = "kakao";
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        log.info("CustomOAuth2UserService.loadUser() 실행 - OAuth2 로그인 요청 진입");
+
+        /**
+         * DefaultOAuth2UserService 객체를 생성하여, loadUser(userRequest)를 통해 DefaultOAuth2User 객체를 생성 후 반환
+         * DefaultOAuth2UserService의 loadUser()는 소셜 로그인 API의 사용자 정보 제공 URI로 요청을 보내서
+         * 사용자 정보를 얻은 후, 이를 통해 DefaultOAuth2User 객체를 생성 후 반환한다.
+         * 결과적으로, OAuth2User는 OAuth 서비스에서 가져온 유저 정보를 담고 있는 유저
+         */
+        OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+
+        // 여기에 로그 추가
+        log.info("API 응답 데이터: {}", oAuth2User.getAttributes());
+
+        /**
+         * userRequest에서 registrationId 추출 후 registrationId으로 SocialType 저장
+         * http://localhost:4000/oauth2/authorization/kakao에서 kakao가 registrationId
+         * userNameAttributeName은 이후에 nameAttributeKey로 설정된다.
+         */
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        SocialType socialType = getSocialType(registrationId);
+        String userNameAttributeName = userRequest.getClientRegistration()
+                .getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName(); // OAuth2 로그인 시 키(PK)가 되는 값
+        Map<String, Object> attributes = oAuth2User.getAttributes(); // 소셜 로그인에서 API가 제공하는 userInfo의 Json 값(유저 정보들)
+
+        // socialType에 따라 유저 정보를 통해 OAuthAttributes 객체 생성
+        OAuthAttributes extractAttributes = OAuthAttributes.of(socialType, userNameAttributeName, attributes);
+
+        User createdUser = getUser(extractAttributes, socialType); // getUser() 메소드로 User 객체 생성 후 반환
+
+        // DefaultOAuth2User를 구현한 CustomOAuth2User 객체를 생성해서 반환
+        return new CustomOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority(createdUser.getRole().getKey())),
+                attributes,
+                extractAttributes.getNameAttributeKey(),
+                createdUser.getEmail(),
+                createdUser.getRole()
+        );
+    }
+
+    private SocialType getSocialType(String registrationId) {
+        if(NAVER.equals(registrationId)) {
+            return SocialType.NAVER;
+        }
+
+        if(KAKAO.equals(registrationId)) {
+            return SocialType.KAKAO;
+        }
+
+        return SocialType.GOOGLE;
+    }
+
+    /**
+     * SocialType과 attributes에 들어있는 소셜 로그인의 식별값 id를 통해 회원을 찾아 반환하는 메소드
+     * 만약 찾은 회원이 있다면, 그대로 반환하고 없다면 saveUser()를 호출하여 회원을 저장한다.
+     */
+    private User getUser(OAuthAttributes attributes, SocialType socialType) {
+        User findUser = userRepository.findBySocialTypeAndSocialId(socialType,
+                attributes.getOAuth2UserInfo().getId()).orElse(null);
+
+        if(findUser == null) {
+            return saveUser(attributes, socialType);
+        }
+        return findUser;
+    }
+
+    /**
+     * OAuthAttributes의 toEntity() 메소드를 통해 빌더로 User 객체 생성 후 반환
+     * 생성된 User 객체를 DB에 저장 : socialType, socialId, email, role 값만 있는 상태
+     */
+    private User saveUser(OAuthAttributes attributes, SocialType socialType) {
+        User createdUser = attributes.toEntity(socialType, attributes.getOAuth2UserInfo());
+        return userRepository.save(createdUser);
+    }
+}

--- a/src/main/java/com/gongjibot/ragchat/oauth2/userinfo/GoogleOAuth2UserInfo.java
+++ b/src/main/java/com/gongjibot/ragchat/oauth2/userinfo/GoogleOAuth2UserInfo.java
@@ -1,0 +1,25 @@
+package com.gongjibot.ragchat.oauth2.userinfo;
+
+import java.util.Map;
+
+public class GoogleOAuth2UserInfo extends OAuth2UserInfo {
+
+    public GoogleOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        return (String) attributes.get("sub");
+    }
+
+    @Override
+    public String getNickname() {
+        return (String) attributes.get("name");
+    }
+
+    @Override
+    public String getImageUrl() {
+        return (String) attributes.get("picture");
+    }
+}

--- a/src/main/java/com/gongjibot/ragchat/oauth2/userinfo/KakaoOAuth2UserInfo.java
+++ b/src/main/java/com/gongjibot/ragchat/oauth2/userinfo/KakaoOAuth2UserInfo.java
@@ -1,0 +1,49 @@
+package com.gongjibot.ragchat.oauth2.userinfo;
+
+import java.util.Map;
+
+public class KakaoOAuth2UserInfo extends OAuth2UserInfo {
+
+    public KakaoOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        return String.valueOf(attributes.get("id"));
+    }
+
+    @Override
+    public String getNickname() {
+        Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+
+        if (account == null) {
+            return null;
+        }
+
+        Map<String, Object> profile = (Map<String, Object>) account.get("profile");
+
+        if (profile == null) {
+            return null;
+        }
+
+        return (String) profile.get("nickname");
+    }
+
+    @Override
+    public String getImageUrl() {
+        Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+
+        if (account == null) {
+            return null;
+        }
+
+        Map<String, Object> profile = (Map<String, Object>) account.get("profile");
+
+        if (profile == null) {
+            return null;
+        }
+
+        return (String) profile.get("thumbnail_image_url");
+    }
+}

--- a/src/main/java/com/gongjibot/ragchat/oauth2/userinfo/NaverOAuth2UserInfo.java
+++ b/src/main/java/com/gongjibot/ragchat/oauth2/userinfo/NaverOAuth2UserInfo.java
@@ -1,0 +1,42 @@
+package com.gongjibot.ragchat.oauth2.userinfo;
+
+import java.util.Map;
+
+public class NaverOAuth2UserInfo extends OAuth2UserInfo {
+
+    public NaverOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+
+        if (response == null) {
+            return null;
+        }
+        return (String) response.get("id");
+    }
+
+    @Override
+    public String getNickname() {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+
+        if (response == null) {
+            return null;
+        }
+
+        return (String) response.get("name");
+    }
+
+    @Override
+    public String getImageUrl() {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+
+        if (response == null) {
+            return null;
+        }
+
+        return (String) response.get("profile_image");
+    }
+}

--- a/src/main/java/com/gongjibot/ragchat/oauth2/userinfo/OAuth2UserInfo.java
+++ b/src/main/java/com/gongjibot/ragchat/oauth2/userinfo/OAuth2UserInfo.java
@@ -1,0 +1,18 @@
+package com.gongjibot.ragchat.oauth2.userinfo;
+
+import java.util.Map;
+
+public abstract class OAuth2UserInfo {
+
+    protected Map<String, Object> attributes;
+
+    public OAuth2UserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    public abstract String getId(); //소셜 식별 값 : 구글 - "sub", 카카오 - "id", 네이버 - "id"
+
+    public abstract String getNickname();
+
+    public abstract String getImageUrl();
+}

--- a/src/main/java/com/gongjibot/ragchat/repository/UserRepository.java
+++ b/src/main/java/com/gongjibot/ragchat/repository/UserRepository.java
@@ -8,7 +8,6 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByNickname(String nickname);
-    Optional<User> findByUsername(String username);
     Optional<User> findByEmail(String email);
     Optional<User> findByRefreshToken(String refreshToken);
 

--- a/src/main/java/com/gongjibot/ragchat/service/UserService.java
+++ b/src/main/java/com/gongjibot/ragchat/service/UserService.java
@@ -36,10 +36,6 @@ public class UserService {
     public void singUp(SignUpRequestDto dto) {
         String encodePassword = passwordEncoder.encode(dto.password());
 
-        if (userRepository.findByUsername(dto.username()).isPresent()) {
-            throw new BadRequestException(ErrorCode.USER_NAME_DUPLICATED);
-        }
-
         if (userRepository.findByNickname(dto.nickname()).isPresent()) {
             throw new BadRequestException(ErrorCode.NICK_NAME_DUPLICATED);
         }
@@ -54,9 +50,8 @@ public class UserService {
             throw new BadRequestException(ErrorCode.CERTIFICATION_MISMATCH);
 
         User user = User.builder()
-                .username(dto.username())
-                .password(encodePassword)
                 .email(dto.email())
+                .password(encodePassword)
                 .nickname(dto.nickname())
                 .role(Role.USER)
                 .build();
@@ -106,20 +101,20 @@ public class UserService {
         });
     }
 
-    @Transactional
-    public String findId(FindIdRequestDto dto) {
-        User user = userRepository.findByEmail(dto.email())
-                .orElseThrow(() -> new BadRequestException(ErrorCode.USER_NOT_FOUND));
-
-        Certification certification = certificationRepository.findFirstByEmailOrderByCreateDateDesc(dto.email())
-                .orElseThrow(() -> new BadRequestException(ErrorCode.CERTIFICATION_FAIL));
-
-        boolean isMatched = certification.getVerificationCode().getCode().equals(dto.code());
-        if (!isMatched) throw new BadRequestException(ErrorCode.CERTIFICATION_MISMATCH);
-
-        certificationRepository.deleteByEmail(dto.email());
-        return user.getUsername();
-    }
+//    @Transactional
+//    public String findId(FindIdRequestDto dto) {
+//        User user = userRepository.findByEmail(dto.email())
+//                .orElseThrow(() -> new BadRequestException(ErrorCode.USER_NOT_FOUND));
+//
+//        Certification certification = certificationRepository.findFirstByEmailOrderByCreateDateDesc(dto.email())
+//                .orElseThrow(() -> new BadRequestException(ErrorCode.CERTIFICATION_FAIL));
+//
+//        boolean isMatched = certification.getVerificationCode().getCode().equals(dto.code());
+//        if (!isMatched) throw new BadRequestException(ErrorCode.CERTIFICATION_MISMATCH);
+//
+//        certificationRepository.deleteByEmail(dto.email());
+//        return user.getUsername();
+//    }
 
     @Transactional
     public void passwordReset(PasswordResetDto dto) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,7 @@ spring:
       - security/application-db.yml
       - security/application-mail.yml
       - security/application-jwt.yml
+      - security/application-oauth.yml
 
 jwt:
   secretKey: ${JWT_SECRET_KEY}

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,3 @@
+<a href="/oauth2/authorization/kakao">Kakao Login</a><br>
+<a href="/oauth2/authorization/google">Google Login</a><br>
+<a href="/oauth2/authorization/naver">Naver Login</a><br>


### PR DESCRIPTION
📌 기능 개발 요소
- GOOGLE, KAKAO, NAVER 계정을 이용한 소셜 로그인 기능 개발
- 프로젝트 요구사항에 맞춰 회원가입 시 이메일, 비밀번호 정보만 입력받고 이메일, 비밀번호로 로그인할 수 있도록 구성함
-> 기존의 아이디 찾기 기능 삭제

📌 개선해야할 점
- OAuth 2.0 로그인 시 액세스 및 리프레시 토큰을 업데이트 하는 로직 수정 필요
- NAVER, GOOGLE을 둘 다 사용하는 등 여러 OAuth 2.0를 사용하는 경우에 대한 로직 추가 필요