### PR TITLE
FIX: 글로벌 예외처리 설정

### DIFF
--- a/src/main/java/com/gongjibot/ragchat/common/exception/ErrorResponse.java
+++ b/src/main/java/com/gongjibot/ragchat/common/exception/ErrorResponse.java
@@ -1,0 +1,17 @@
+package com.gongjibot.ragchat.common.exception;
+
+import java.time.LocalDateTime;
+
+public record ErrorResponse(
+  String code,
+  String message,
+  LocalDateTime timestamp
+) {
+  public ErrorResponse(ErrorCode errorCode) {
+    this(errorCode.name(), errorCode.getMessage(), LocalDateTime.now());
+  }
+  
+  public ErrorResponse(String code, String message) {
+    this(code, message, LocalDateTime.now());
+  }
+} 

--- a/src/main/java/com/gongjibot/ragchat/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/gongjibot/ragchat/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,56 @@
+package com.gongjibot.ragchat.common.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<ErrorResponse> handleBadRequestException(BadRequestException ex) {
+        log.error("BadRequestException: {}", ex.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(ex.getErrorCode()));
+    }
+
+    @ExceptionHandler(RagchatException.class)
+    public ResponseEntity<ErrorResponse> handleRagchatException(RagchatException ex) {
+        log.error("RagchatException: {}", ex.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ErrorResponse(ex.getErrorCode()));
+    }
+
+    @ExceptionHandler({MethodArgumentNotValidException.class, BindException.class})
+    public ResponseEntity<ErrorResponse> handleValidationExceptions(Exception ex) {
+        log.error("Validation Exception: {}", ex.getMessage());
+        String errorMessage = "입력값이 올바르지 않습니다";
+        
+        if (ex instanceof MethodArgumentNotValidException) {
+            errorMessage = ((MethodArgumentNotValidException) ex).getBindingResult()
+                    .getAllErrors().get(0).getDefaultMessage();
+        } else if (ex instanceof BindException) {
+            errorMessage = ((BindException) ex).getBindingResult()
+                    .getAllErrors().get(0).getDefaultMessage();
+        }
+        
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse("INVALID_INPUT", errorMessage));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleAllExceptions(Exception ex) {
+        log.error("Unhandled Exception: ", ex);
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ErrorResponse("SERVER_ERROR", "서버 오류가 발생했습니다"));
+    }
+} 


### PR DESCRIPTION
### ❗ BadRequestException 실행 오류
OAuth 2.0 설정 이후 기존에 설계한 예외처리인 BadRequestException이 실행되지 않고 테스트 파일인 index.html 코드를 반환하는 문제 발생

### 🧑‍💻 GlobalExceptionHandler 설정
`@RestControllerAdvice` 어노테이션을 사용하여 Spring Security나 컨텐츠 협상보다 높은 우선순위로 예외 처리가 진행되도록 설정하여 항상 일관된 JSON 응답을 반환하도록 보장함